### PR TITLE
Fix Yubikey nonce generation

### DIFF
--- a/src/Crypto/RandomNonceGenerator.php
+++ b/src/Crypto/RandomNonceGenerator.php
@@ -6,6 +6,7 @@ class RandomNonceGenerator implements NonceGenerator
 {
     public function generateNonce()
     {
+        // Nonces can only be 16 to 40 character long according to the yubico specification
         return bin2hex(random_bytes(20));
     }
 }

--- a/src/Crypto/RandomNonceGenerator.php
+++ b/src/Crypto/RandomNonceGenerator.php
@@ -6,6 +6,6 @@ class RandomNonceGenerator implements NonceGenerator
 {
     public function generateNonce()
     {
-        return bin2hex(random_bytes(32));
+        return bin2hex(random_bytes(20));
     }
 }

--- a/tests/unit/Crypto/RandomNonceGeneratorTest.php
+++ b/tests/unit/Crypto/RandomNonceGeneratorTest.php
@@ -6,11 +6,11 @@ use Surfnet\YubikeyApiClient\Crypto\RandomNonceGenerator;
 
 class RandomNonceGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function testItGeneratesMd5Nonce()
+    public function testItGeneratesAHexNonceOfTheCorrectLength()
     {
         $generator = new RandomNonceGenerator;
         $nonce = $generator->generateNonce();
 
-        $this->assertSame(1, preg_match('/^[a-f0-9]{64}$/', $nonce));
+        $this->assertSame(1, preg_match('/^[a-f0-9]{40}$/', $nonce));
     }
 }


### PR DESCRIPTION
Nonces can only be 16 to 40 character long according to the yubico specification: https://developers.yubico.com/OTP/Specifications/OTP_validation_protocol.html