### PR TITLE
Simplify ServerPoolClient

### DIFF
--- a/src/Http/ServerPoolClient.php
+++ b/src/Http/ServerPoolClient.php
@@ -10,13 +10,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class ServerPoolClient
 {
-    private static $serverPool = [
-        'https://api.yubico.com/wsapi/2.0/verify',
-        'https://api2.yubico.com/wsapi/2.0/verify',
-        'https://api3.yubico.com/wsapi/2.0/verify',
-        'https://api4.yubico.com/wsapi/2.0/verify',
-        'https://api5.yubico.com/wsapi/2.0/verify',
-    ];
+    const YUBICO_API_VERIFY = 'https://api.yubico.com/wsapi/2.0/verify';
 
     /**
      * @var Client
@@ -37,23 +31,11 @@ class ServerPoolClient
      */
     public function get(array $requestOptions): ResponseInterface
     {
-        $poolIndex = array_rand(self::$serverPool);
-        try {
-            return $this->guzzleClient->get(self::$serverPool[$poolIndex], $requestOptions);
-        } catch (RequestException $e) {
-            if ($e->getResponse()) {
-                throw $e;
-            }
-        }
-
-        // There is no server response (timeout, DNS failure); try again.
-        $poolIndex = ($poolIndex + 1) % count(self::$serverPool);
-
-        return $this->guzzleClient->get(self::$serverPool[$poolIndex], $requestOptions);
+        return $this->guzzleClient->get(self::YUBICO_API_VERIFY, $requestOptions);
     }
 
     public function getServerPool(): array
     {
-        return self::$serverPool;
+        return [self::YUBICO_API_VERIFY];
     }
 }

--- a/tests/unit/Http/ServerPoolClientTest.php
+++ b/tests/unit/Http/ServerPoolClientTest.php
@@ -23,48 +23,6 @@ class ServerPoolClientTest extends \PHPUnit\Framework\TestCase
         $client->get([]);
     }
 
-    public function testItTriesTwice(): void
-    {
-        $returnValues = [
-            new RequestException('Comms failure', m::mock('Psr\Http\Message\RequestInterface'), /*No response*/ null),
-            m::mock('Psr\Http\Message\ResponseInterface'),
-        ];
-
-        $client = new ServerPoolClient(
-            m::mock('GuzzleHttp\Client')
-                ->shouldReceive('get')->twice()->andReturnUsing(function () use (&$returnValues) {
-                    $r = array_shift($returnValues);
-                    if ($r instanceof RequestException) {
-                        throw $r;
-                    }
-                    return $r;
-                })
-                ->getMock()
-        );
-
-        $client->get([]);
-    }
-
-    public function testItThrowsGuzzlesExceptionAfterTryingTwice(): void
-    {
-        $this->expectException('GuzzleHttp\Exception\RequestException', 'Comms failure #2');
-
-        $exceptions = [
-            new RequestException('Comms failure #1', m::mock('Psr\Http\Message\RequestInterface'), null),
-            new RequestException('Comms failure #2', m::mock('Psr\Http\Message\RequestInterface'), null),
-        ];
-
-        $client = new ServerPoolClient(
-            m::mock('GuzzleHttp\Client')
-                ->shouldReceive('get')->twice()->andReturnUsing(function () use (&$exceptions) {
-                    throw array_shift($exceptions);
-                })
-                ->getMock()
-        );
-
-        $client->get([]);
-    }
-
     public function testItThrowsGuzzlesExceptionWhenItHasAResponse(): void
     {
         $this->expectException('GuzzleHttp\Exception\RequestException', 'Internal server error');


### PR DESCRIPTION
Yubico [no longer uses](https://status.yubico.com/2021/04/15/one-api-yubico-com-one-http-get/) an API which needs requests to be sent to
multiple endpoints, but rather has one geolocated API endpoint.
This removes the logic to try multiple and thereby simplifies
the code.

This is the most simplification we can do without breaking
the library's published interface. We can do that (would probably
mean to remove the SeverPoolClient altogether) but that breaks
implementers for no clear gain at this point. Just simplifying
the current code has a great benefit/cost tradeoff.